### PR TITLE
シェーダの読み込みパスを修正

### DIFF
--- a/SampleVideoEffects/SampleHLSLShaderVideoEffect/ShaderResourceLoader.cs
+++ b/SampleVideoEffects/SampleHLSLShaderVideoEffect/ShaderResourceLoader.cs
@@ -12,7 +12,7 @@ namespace SampleVideoEffects.SampleHLSLShaderEffect
         public static byte[] GetShaderResource(string name)
         {
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = $"SampleVideoEffects.SampleHLSLShaderEffect.{name}";
+            var resourceName = $"SampleVideoEffects.SampleHLSLShaderVideoEffect.{name}";
             using var stream = assembly.GetManifestResourceStream(resourceName) ?? throw new Exception($"Resource {resourceName} not found.");
             var bytes = new byte[stream.Length];
             stream.Read(bytes, 0, bytes.Length);


### PR DESCRIPTION
プラグイン機能実装お疲れ様です

サンプルを手元でビルドして試していたところ、シェーダが読み込めない現象に遭遇しました
調査すると本PRの通りに修正することで正常に動作させることに成功しました
こちらのほうがファイルパスと一致していますので元のものがミスの可能性があると考えPRを送らせていただきます