### PR TITLE
VSCodeを使用している場合に「Path」が存在しないエラーを修正

### DIFF
--- a/SampleAudioSourcePlugin/SampleAudioSourcePlugin.cs
+++ b/SampleAudioSourcePlugin/SampleAudioSourcePlugin.cs
@@ -1,4 +1,5 @@
 ﻿using YukkuriMovieMaker.Plugin.FileSource;
+using System.IO;
 
 namespace SampleAudioSourcePlugin
 {


### PR DESCRIPTION
お疲れ様です。

[この記事](https://zenn.dev/inuinu/scraps/287c1d83e7f67c)を見ながらVSCodeでサンプルをビルドしていたところ、エラーが発生しました。
Using System.IOを追加することで解決したため、PRを送らせていただきます。

宜しくお願い致します。